### PR TITLE
Drop "future" package from runtime dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - setuptools
   run:
     - python >={{ python_min }}
-    - future >=0.15
     - numpy >=1.0
     - spglib >=1.9.4
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
 


### PR DESCRIPTION
It isn't clear that this is needed anywhere in the code.

An arbitrary code execution vulnerability was recently reported in the "future" package
https://medium.com/@abcd_68700/cve-2025-50817-python-future-module-arbitrary-code-execution-via-unintended-import-of-test-py-f0818ea93cf4

So the unexpected/unnecessary appearance of this package is making downstream projects nervous: https://github.com/mantidproject/mantid/pull/39848

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
